### PR TITLE
3.1.6 update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2013 - 2019 Antonio Marin
+Copyright (c) 2013 - 2021 Antonio Marin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ android {
         applicationId "com.am.stbus"
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 69
+        versionCode 70
         versionName "3.1.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         android.defaultConfig.vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -84,31 +84,31 @@ ext {
     appcompat_version = "1.2.0"
     core_ktx_version = "1.3.2"
     recyclerview_version = "1.1.0"
-    browser_version = "1.2.0"
+    browser_version = "1.3.0"
     swipe_refresh_version = "1.1.0"
-    constraint_layout_version = "2.0.2"
+    constraint_layout_version = "2.0.4"
     vector_drawable_version = "1.0.0"
     preference_ktx_version = "1.1.1"
 
     // Navigation
-    nav_version_ktx_version = "2.3.1"
+    nav_version_ktx_version = "2.3.3"
 
     // ViewModel and LiveData
     lifecycle_version = "2.2.0"
 
     // Room
-    room_version = "2.2.5"
+    room_version = "2.2.6"
 
     // Gmaps
     play_services_maps_version = "17.0.0"
     play_services_location_version = "17.1.0"
 
     // Firebase Analytics
-    firebase_analytics_version = "17.6.0"
-    firebase_crashlytics_version = "17.2.2"
+    firebase_analytics_version = "18.0.2"
+    firebase_crashlytics_version = "17.3.1"
 
     // Material
-    material_components_version = "1.3.0-alpha03"
+    material_components_version = "1.3.0-rc01"
 
     // Koin
     koin_version = "2.1.6"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,8 +38,8 @@ android {
         applicationId "com.am.stbus"
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 68
-        versionName "3.1.5"
+        versionCode 67
+        versionName "3.1.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         android.defaultConfig.vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
@@ -144,8 +144,8 @@ dependencies {
     // Testing
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     testImplementation 'junit:junit:4.13.1'
-    androidTestImplementation 'androidx.test:runner:1.3.1-alpha01'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0-alpha01'
+    androidTestImplementation 'androidx.test:runner:1.3.1-alpha03'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0-alpha03'
 
     // AndroidX
     implementation "androidx.appcompat:appcompat:$appcompat_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ android {
         applicationId "com.am.stbus"
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 67
+        versionCode 69
         versionName "3.1.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         android.defaultConfig.vectorDrawables.useSupportLibrary = true

--- a/app/src/androidTest/java/com/am/stbus/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/am/stbus/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/debug/res/values-hr/strings.xml
+++ b/app/src/debug/res/values-hr/strings.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2020 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2020 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,4 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.am.stbus">

--- a/app/src/main/assets/licenses.html
+++ b/app/src/main/assets/licenses.html
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/SplitBusApplication.kt
+++ b/app/src/main/java/com/am/stbus/SplitBusApplication.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/common/Constants.kt
+++ b/app/src/main/java/com/am/stbus/common/Constants.kt
@@ -26,7 +26,7 @@ package com.am.stbus.common
 
 object Constants {
 
-    const val DB_VERSION = 2
+    const val DB_VERSION = 3
 
     const val PROMET_URL = "http://www.promet-split.hr"
     const val PROMET_NOVOSTI_URL = "http://www.promet-split.hr/obavijesti"

--- a/app/src/main/java/com/am/stbus/common/Constants.kt
+++ b/app/src/main/java/com/am/stbus/common/Constants.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/common/TimetablesData.kt
+++ b/app/src/main/java/com/am/stbus/common/TimetablesData.kt
@@ -145,16 +145,25 @@ class TimetablesData {
                 306 -> R.string.bus442
                 307 -> R.string.bus451
                 308 -> R.string.bus452
-                309 -> R.string.bus47
-                310 -> R.string.bus48
-                311 -> R.string.bus491
-                312 -> R.string.bus492
-                313 -> R.string.bus501
-                314 -> R.string.bus502
-                315 -> R.string.bus511
-                316 -> R.string.bus512
-                317 -> R.string.bus521
-                318 -> R.string.bus522
+                309 -> R.string.bus471
+                310 -> R.string.bus472
+                311 -> R.string.bus4911
+                312 -> R.string.bus4912
+                313 -> R.string.bus4921
+                314 -> R.string.bus4922
+                315 -> R.string.bus5011
+                316 -> R.string.bus5012
+                317 -> R.string.bus5021
+                318 -> R.string.bus5022
+                319 -> R.string.bus5023
+                322 -> R.string.bus511
+                323 -> R.string.bus512
+                324 -> R.string.bus5211
+                325 -> R.string.bus5212
+                326 -> R.string.bus5213
+                327 -> R.string.bus5214
+                328 -> R.string.bus5215
+
 
                 401 -> R.string.buss1
                 402 -> R.string.buss2
@@ -184,8 +193,8 @@ class TimetablesData {
                 16 -> "18 BRNIK - HNK - BRNIK"
                 17 -> "20 RAVNE NJIVE - ZVONČAC"
                 18 -> "21 SV.FRANE - MEJE - SV.FRANE"
-                19 -> "24 SPLIT - KOPILICA - DOM. RATA - STOBREČ - TTTS"
-                20 -> "24 TTTS - STOBREČ - DOM. RATA - KOPILICA - SPLIT"
+                19 -> "24 SPLIT - POLJIČKA - TTTS"
+                20 -> "24 TTTS -POLJIČKA - SPLIT"
                 21 -> "25 SPLIT - STOBREČ"
                 22 -> "25 STOBREČ - SPLIT"
                 23 -> "26 SPLIT - KAMEN"
@@ -202,7 +211,7 @@ class TimetablesData {
                 104 -> "2A K. SUĆURAC(STRINJE) - TR. LUKA - K. SUĆURAC(STRINJE)"
                 105 -> "5 DRAČEVAC - HNK - DRAČEVAC"
                 106 -> "5A DRAČEVAC -SOLIN- VISOKA- HNK - DRAČEVAC"
-                107 -> "10 JAPIRKO - HNK - JAPIRKO"
+                107 -> "10 JAPIRKO"
                 108 -> "16 NINČEVIĆI - HNK - NINČEVIĆI"
                 109 -> "22 KLIS MEGDAN-G.RUPOTINA-HNK-KLIS MEGDAN"
                 110 -> "23 HNK - SOLIN - HNK"
@@ -232,9 +241,9 @@ class TimetablesData {
                 134 -> "60 RAVNIČKI MOST - OMIŠ - SPLIT"
                 135 -> "ŽELJEZNIČKA STANICA - KAŠTEL STARI"
                 136 -> "KAŠTEL STARI - ŽELJEZNIČKA STANICA"
-                137 -> "TROGIR KOLODVOR - ŽELJEZNIČKA STANICA (K. STARI) INTEGRIRANA LINIJA (INTEGRATED LINE)"
-                138 -> "ŽELJEZNIČKA STANICA (K. STARI) - TROGIR KOLODVOR INTEGRIRANA LINIJA (INTEGRATED LINE)"
-                139 -> "TROGIR - SPLIT (direktna)"
+                137 -> "TROGIR KOLODVOR - ŽELJEZNIČKA STANICA"
+                138 -> "ŽELJEZNIČKA STANICA (K. STARI) - TROGIR KOLODVOR INTEGRIRANA "
+                139 -> "TROGIR - SPLIT"
 
 
                 // Prigradsko
@@ -270,24 +279,33 @@ class TimetablesData {
                 227 -> "RUDINE - KAŠTEL STARI"
 
                 // Trogir i Solta
-                301 -> "41 TROGIR - PLANO - MALJKOVIĆI"
-                302 -> "41 MALJKOVIĆI - PLANO - TROGIR"
+                301 -> "41 TROGIR"
+                302 -> "41 PLANO"
                 303 -> "42 TROGIR - SLATINE"
                 304 -> "42 SLATINE - TROGIR"
                 305 -> "44 TROGIR - OKRUG DONJI"
                 306 -> "44 OKRUG DONJI - TROGIR"
-                307 -> "45 TROGIR - HOTEL MEDENA - VRANJICA"
-                308 -> "45 VRANJICA - HOTEL MEDENA - TROGIR"
-                309 -> "47 TROGIR - HOTEL MEDENA - VRSINE - MARINA - TROGIR"
-                310 -> "48 TROGIR - HOTEL MEDENA - MARINA - DOGRADE - VRSINE - TROGIR"
-                311 -> "49 TROGIR - HOTEL MEDENA - VINIŠĆE"
-                312 -> "49 VINIŠĆE - HOTEL MEDENA - TROGIR"
-                313 -> "50 TROGIR - HOTEL MEDENA - SEVID"
-                314 -> "50 SEVID - HOTEL MEDENA - TROGIR"
-                315 -> "51 TROGIR - LJUBITOVICA"
-                316 -> "51 LJUBITOVICA - TROGIR"
-                317 -> "52 TROGIR - VINOVAC"
-                318 -> "52 VINOVAC - TROGIR"
+                307 -> "45 TROGIR"
+                308 -> "45 VRANJICA"
+                309 -> "47 TROGIR"
+                310 -> "47 MARINA"
+                311 -> "49 TROGIR - MARINA - VINIŠĆE"
+                312 -> "49 TROGIR - VRSINE - MARINA - VINIŠĆE"
+                313 -> "49 VINIŠĆE - MARINA"
+                314 -> "49 VINIŠĆE - MARINA - TROGIR"
+                315 -> "50 TROGIR -VRSINE - MARINA - SEVID"
+                316 -> "50 TROGIR - MARINA - VINIŠĆE - SEVID"
+                317 -> "50 SEVID - VINIŠĆE -TROGIR"
+                318 -> "50 SEVID -TROGIR"
+                319 -> "50 SEVID -MARINA"
+                322 -> "51 TROGIR"
+                323 -> "51 LJUBITOVICA"
+                324 -> "52 TROGIR - VRSINE -"
+                325 -> "52 VINOVAC - BLIZNA - DOGRADE"
+                326 -> "52 MARINA (OKRETIŠTE) - VINOVAC"
+                327 -> "52 VINOVAC - BLIZNA - MARINA - DOGRADE"
+                328 -> "52 VINOVAC - BLIZNA - MARINA - TROGIR"
+
 
                 401 -> "MASLINICA - DONJE SELO - SREDNJE SELO - GROHOTE - ROGAČ"
                 402 -> "ROGAČ - GROHOTE - SREDNJE SELO - DONJE SELO - MASLINICA"
@@ -415,15 +433,23 @@ class TimetablesData {
                 Timetable(307, "45", 31, AREA_TROGIR, 0, "", ""),
                 Timetable(308, "45", 31, AREA_TROGIR, 0, "", ""),
                 Timetable(309, "47", 31, AREA_TROGIR, 0, "", ""),
-                Timetable(310, "48", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(310, "47", 31, AREA_TROGIR, 0, "", ""),
                 Timetable(311, "49", 31, AREA_TROGIR, 0, "", ""),
                 Timetable(312, "49", 31, AREA_TROGIR, 0, "", ""),
-                Timetable(313, "50", 31, AREA_TROGIR, 0, "", ""),
-                Timetable(314, "50", 31, AREA_TROGIR, 0, "", ""),
-                Timetable(315, "51", 31, AREA_TROGIR, 0, "", ""),
-                Timetable(316, "51", 31, AREA_TROGIR, 0, "", ""),
-                Timetable(317, "52", 31, AREA_TROGIR, 0, "", ""),
-                Timetable(318, "52", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(313, "49", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(314, "49", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(315, "50", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(316, "50", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(317, "50", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(318, "50", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(319, "50", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(322, "51", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(323, "51", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(324, "52", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(325, "52", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(326, "52", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(327, "52", 31, AREA_TROGIR, 0, "", ""),
+                Timetable(328, "52", 31, AREA_TROGIR, 0, "", ""),
 
                 Timetable(401, "", 31, AREA_SOLTA, 0, "", ""),
                 Timetable(402, "", 31, AREA_SOLTA, 0, "", ""),

--- a/app/src/main/java/com/am/stbus/common/TimetablesData.kt
+++ b/app/src/main/java/com/am/stbus/common/TimetablesData.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/common/TimetablesData.kt
+++ b/app/src/main/java/com/am/stbus/common/TimetablesData.kt
@@ -201,7 +201,7 @@ class TimetablesData {
                 103 -> "2 SPLIT- POLJIČKA - K. SUĆURAC (STRINJE) - ZRAČNA L."
                 104 -> "2A K. SUĆURAC(STRINJE) - TR. LUKA - K. SUĆURAC(STRINJE)"
                 105 -> "5 DRAČEVAC - HNK - DRAČEVAC"
-                106 -> "5A DRAČEVAC - SOLIN - VISOKA - HNK - DRAČEVAC"
+                106 -> "5A DRAČEVAC -SOLIN- VISOKA- HNK - DRAČEVAC"
                 107 -> "10 JAPIRKO - HNK - JAPIRKO"
                 108 -> "16 NINČEVIĆI - HNK - NINČEVIĆI"
                 109 -> "22 KLIS MEGDAN-G.RUPOTINA-HNK-KLIS MEGDAN"

--- a/app/src/main/java/com/am/stbus/common/di/ApplicationModule.kt
+++ b/app/src/main/java/com/am/stbus/common/di/ApplicationModule.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/common/di/LocalModules.kt
+++ b/app/src/main/java/com/am/stbus/common/di/LocalModules.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/common/di/NetworkModules.kt
+++ b/app/src/main/java/com/am/stbus/common/di/NetworkModules.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/common/di/RepositoriesModule.kt
+++ b/app/src/main/java/com/am/stbus/common/di/RepositoriesModule.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/common/di/UseCaseModule.kt
+++ b/app/src/main/java/com/am/stbus/common/di/UseCaseModule.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/common/di/ViewModelModule.kt
+++ b/app/src/main/java/com/am/stbus/common/di/ViewModelModule.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +33,6 @@ import com.am.stbus.presentation.screens.timetables.TimetablesViewModel
 import com.am.stbus.presentation.screens.timetables.timetablesListFragment.TimetablesListViewModel
 import com.am.stbus.presentation.screens.timetables.timetablesListFragment.timetableDetailFragment.TimetableDetailFragmentArgs
 import com.am.stbus.presentation.screens.timetables.timetablesListFragment.timetableDetailFragment.TimetableDetailViewModel
-import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 

--- a/app/src/main/java/com/am/stbus/common/extensions/CommonExtensions.kt
+++ b/app/src/main/java/com/am/stbus/common/extensions/CommonExtensions.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/common/extensions/ViewExtensions.kt
+++ b/app/src/main/java/com/am/stbus/common/extensions/ViewExtensions.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/common/helpers/Event.kt
+++ b/app/src/main/java/com/am/stbus/common/helpers/Event.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/am/stbus/data/local/AppDatabase.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/data/local/NewsDao.kt
+++ b/app/src/main/java/com/am/stbus/data/local/NewsDao.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/data/local/TimetableDao.kt
+++ b/app/src/main/java/com/am/stbus/data/local/TimetableDao.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/data/network/RemoteNewsDataSource.kt
+++ b/app/src/main/java/com/am/stbus/data/network/RemoteNewsDataSource.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/data/network/RemoteTimetableDataSource.kt
+++ b/app/src/main/java/com/am/stbus/data/network/RemoteTimetableDataSource.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/data/repositoriesImpl/NewsRepositoryImpl.kt
+++ b/app/src/main/java/com/am/stbus/data/repositoriesImpl/NewsRepositoryImpl.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/data/repositoriesImpl/TimetableRepositoryImpl.kt
+++ b/app/src/main/java/com/am/stbus/data/repositoriesImpl/TimetableRepositoryImpl.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/models/GmapsBusStop.kt
+++ b/app/src/main/java/com/am/stbus/domain/models/GmapsBusStop.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/models/Information.kt
+++ b/app/src/main/java/com/am/stbus/domain/models/Information.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/models/NewsItem.kt
+++ b/app/src/main/java/com/am/stbus/domain/models/NewsItem.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/models/NewsListItem.kt
+++ b/app/src/main/java/com/am/stbus/domain/models/NewsListItem.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/models/Notification.kt
+++ b/app/src/main/java/com/am/stbus/domain/models/Notification.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/models/Timetable.kt
+++ b/app/src/main/java/com/am/stbus/domain/models/Timetable.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/repositories/NewsRepository.kt
+++ b/app/src/main/java/com/am/stbus/domain/repositories/NewsRepository.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/repositories/TimetableRepository.kt
+++ b/app/src/main/java/com/am/stbus/domain/repositories/TimetableRepository.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/usecases/news/NewsDetailUseCase.kt
+++ b/app/src/main/java/com/am/stbus/domain/usecases/news/NewsDetailUseCase.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/usecases/news/NewsListUseCase.kt
+++ b/app/src/main/java/com/am/stbus/domain/usecases/news/NewsListUseCase.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/usecases/timetables/TimetableDetailUseCase.kt
+++ b/app/src/main/java/com/am/stbus/domain/usecases/timetables/TimetableDetailUseCase.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/domain/usecases/timetables/TimetableListUseCase.kt
+++ b/app/src/main/java/com/am/stbus/domain/usecases/timetables/TimetableListUseCase.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/MainActivity.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/MainActivity.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/favourites/FavouritesAdapter.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/favourites/FavouritesAdapter.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/favourites/FavouritesFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/favourites/FavouritesFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/favourites/FavouritesViewModel.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/favourites/FavouritesViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/information/InformationListAdapter.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/information/InformationListAdapter.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/information/InformationListFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/information/InformationListFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/information/InformationListViewModel.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/information/InformationListViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,26 +24,7 @@
 
 package com.am.stbus.presentation.screens.information
 
-import android.content.Context
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.am.stbus.R
-import com.am.stbus.common.InformationConstants.ID_CYCLES
-import com.am.stbus.common.InformationConstants.ID_GARAGES
-import com.am.stbus.common.InformationConstants.ID_GENERAL_CATEGORY
-import com.am.stbus.common.InformationConstants.ID_GMAPS
-import com.am.stbus.common.InformationConstants.ID_LATEST_NEWS
-import com.am.stbus.common.InformationConstants.ID_MAPS_CATEGORY
-import com.am.stbus.common.InformationConstants.ID_PARKING
-import com.am.stbus.common.InformationConstants.ID_PROMET_WEB
-import com.am.stbus.common.InformationConstants.ID_SUBURBAN_MAP
-import com.am.stbus.common.InformationConstants.ID_TARIFF_ZONES_MAP
-import com.am.stbus.common.InformationConstants.ID_URBAN_MAP
-import com.am.stbus.common.InformationConstants.ID_WEBSITES_CATEGORY
-import com.am.stbus.common.InformationConstants.TYPE_HEADER
-import com.am.stbus.common.InformationConstants.TYPE_ITEM
-import com.am.stbus.domain.models.Information
 
 class InformationListViewModel() : ViewModel() {
 

--- a/app/src/main/java/com/am/stbus/presentation/screens/information/informationGmapsFragment/InformationGmapsFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/information/informationGmapsFragment/InformationGmapsFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/information/informationImageViewFragment/InformationImageViewFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/information/informationImageViewFragment/InformationImageViewFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/information/informationNewsListFragment/InformationNewsListAdapter.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/information/informationNewsListFragment/InformationNewsListAdapter.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/information/informationNewsListFragment/InformationNewsListFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/information/informationNewsListFragment/InformationNewsListFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/information/informationNewsListFragment/InformationNewsListViewModel.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/information/informationNewsListFragment/InformationNewsListViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,6 @@ import io.reactivex.SingleObserver
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
-import timber.log.Timber
 
 
 class InformationNewsListViewModel(

--- a/app/src/main/java/com/am/stbus/presentation/screens/information/informationNewsListFragment/informationNewsDetailFragment/InformationNewsDetailFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/information/informationNewsListFragment/informationNewsDetailFragment/InformationNewsDetailFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/information/informationNewsListFragment/informationNewsDetailFragment/InformationNewsDetailViewModel.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/information/informationNewsListFragment/informationNewsDetailFragment/InformationNewsDetailViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/information/informationWebViewFragment/InformationWebViewFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/information/informationWebViewFragment/InformationWebViewFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/settings/AboutFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/settings/AboutFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/settings/ContentFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/settings/ContentFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/settings/SettingsFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/timetables/TimetablesFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/timetables/TimetablesFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/timetables/TimetablesSharedViewModel.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/timetables/TimetablesSharedViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/timetables/TimetablesViewModel.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/timetables/TimetablesViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/TimetablesListAdapter.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/TimetablesListAdapter.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,7 +25,6 @@
 package com.am.stbus.presentation.screens.timetables.timetablesListFragment
 
 import android.content.Context
-import android.content.ContextWrapper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/TimetablesListFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/TimetablesListFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/TimetablesListViewModel.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/TimetablesListViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/timetableDetailFragment/TimetableDetailDayFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/timetableDetailFragment/TimetableDetailDayFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/timetableDetailFragment/TimetableDetailFragment.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/timetableDetailFragment/TimetableDetailFragment.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/timetableDetailFragment/TimetableDetailViewModel.kt
+++ b/app/src/main/java/com/am/stbus/presentation/screens/timetables/timetablesListFragment/timetableDetailFragment/TimetableDetailViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable-v21/ic_menu_camera.xml
+++ b/app/src/main/res/drawable-v21/ic_menu_camera.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable-v21/ic_menu_gallery.xml
+++ b/app/src/main/res/drawable-v21/ic_menu_gallery.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable-v21/ic_menu_manage.xml
+++ b/app/src/main/res/drawable-v21/ic_menu_manage.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable-v21/ic_menu_send.xml
+++ b/app/src/main/res/drawable-v21/ic_menu_send.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable-v21/ic_menu_share.xml
+++ b/app/src/main/res/drawable-v21/ic_menu_share.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable-v21/ic_menu_slideshow.xml
+++ b/app/src/main/res/drawable-v21/ic_menu_slideshow.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable-v21/ripple.xml
+++ b/app/src/main/res/drawable-v21/ripple.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_action_overflow.xml
+++ b/app/src/main/res/drawable/ic_action_overflow.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_arrow_back.xml
+++ b/app/src/main/res/drawable/ic_arrow_back.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_arrow_back_black.xml
+++ b/app/src/main/res/drawable/ic_arrow_back_black.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2020 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_developer.xml
+++ b/app/src/main/res/drawable/ic_developer.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_draw_favoriti.xml
+++ b/app/src/main/res/drawable/ic_draw_favoriti.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_draw_gradski.xml
+++ b/app/src/main/res/drawable/ic_draw_gradski.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_draw_informacije.xml
+++ b/app/src/main/res/drawable/ic_draw_informacije.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_draw_novosti.xml
+++ b/app/src/main/res/drawable/ic_draw_novosti.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_draw_postavke.xml
+++ b/app/src/main/res/drawable/ic_draw_postavke.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_draw_prigradski.xml
+++ b/app/src/main/res/drawable/ic_draw_prigradski.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_favorite_add.xml
+++ b/app/src/main/res/drawable/ic_favorite_add.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_favorites_remove.xml
+++ b/app/src/main/res/drawable/ic_favorites_remove.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/nav_drawer_item.xml
+++ b/app/src/main/res/drawable/nav_drawer_item.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/nav_drawer_item_bg.xml
+++ b/app/src/main/res/drawable/nav_drawer_item_bg.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/rectangle_yellow_round_edges.xml
+++ b/app/src/main/res/drawable/rectangle_yellow_round_edges.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/ripple.xml
+++ b/app/src/main/res/drawable/ripple.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/selector_bottom_nav_item.xml
+++ b/app/src/main/res/drawable/selector_bottom_nav_item.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/drawable/side_nav_bar.xml
+++ b/app/src/main/res/drawable/side_nav_bar.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/font/font_bold.xml
+++ b/app/src/main/res/font/font_bold.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/font/font_regular.xml
+++ b/app/src/main/res/font/font_regular.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/font/font_semi_bold.xml
+++ b/app/src/main/res/font/font_semi_bold.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/activity_gmaps.xml
+++ b/app/src/main/res/layout/activity_gmaps.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_content.xml
+++ b/app/src/main/res/layout/fragment_content.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_favourites.xml
+++ b/app/src/main/res/layout/fragment_favourites.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_information_gmaps.xml
+++ b/app/src/main/res/layout/fragment_information_gmaps.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2020 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_information_image_view.xml
+++ b/app/src/main/res/layout/fragment_information_image_view.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_information_list.xml
+++ b/app/src/main/res/layout/fragment_information_list.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_information_news_detail.xml
+++ b/app/src/main/res/layout/fragment_information_news_detail.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_information_news_list.xml
+++ b/app/src/main/res/layout/fragment_information_news_list.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_information_web_view.xml
+++ b/app/src/main/res/layout/fragment_information_web_view.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_timetable.xml
+++ b/app/src/main/res/layout/fragment_timetable.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_timetable_day.xml
+++ b/app/src/main/res/layout/fragment_timetable_day.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_timetables.xml
+++ b/app/src/main/res/layout/fragment_timetables.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_timetables_detail.xml
+++ b/app/src/main/res/layout/fragment_timetables_detail.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/fragment_timetables_list.xml
+++ b/app/src/main/res/layout/fragment_timetables_list.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/item_row_information_header.xml
+++ b/app/src/main/res/layout/item_row_information_header.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/item_row_information_item.xml
+++ b/app/src/main/res/layout/item_row_information_item.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/item_row_news.xml
+++ b/app/src/main/res/layout/item_row_news.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/item_row_timetable.xml
+++ b/app/src/main/res/layout/item_row_timetable.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/preferences_category.xml
+++ b/app/src/main/res/layout/preferences_category.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/snippet_dialog_licenses.xml
+++ b/app/src/main/res/layout/snippet_dialog_licenses.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/snippet_error.xml
+++ b/app/src/main/res/layout/snippet_error.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/snippet_gmaps_stanica.xml
+++ b/app/src/main/res/layout/snippet_gmaps_stanica.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/layout/snippet_loading.xml
+++ b/app/src/main/res/layout/snippet_loading.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/menu/menu_gmaps.xml
+++ b/app/src/main/res/menu/menu_gmaps.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/menu/menu_gmaps_old.xml
+++ b/app/src/main/res/menu/menu_gmaps_old.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2020 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/menu/menu_timetable.xml
+++ b/app/src/main/res/menu/menu_timetable.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/menu/menu_timetable_list.xml
+++ b/app/src/main/res/menu/menu_timetable_list.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values-hr/arrays.xml
+++ b/app/src/main/res/values-hr/arrays.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -103,6 +103,8 @@
     <string name="gmaps_route_92">9 - Trajektna Luka &#8212;> Ravne Njive</string>
     <string name="gmaps_route_111">11 - Ravne Njive &#8212;> HNK</string>
     <string name="gmaps_route_112">11 - HNK &#8212;> Ravne Njive</string>
+    <string name="gmaps_route_151">15 - Duilovo &#8212;> Trajektna Luka</string>
+    <string name="gmaps_route_152">15 - Trajektna Luka &#8212;> Duilovo</string>
     <string name="gmaps_route_181">18 - Brnik &#8212;> HNK</string>
     <string name="gmaps_route_182">18 - HNK &#8212;> Brnik</string>
     <string name="gmaps_route_401">40 - Kila &#8212;> Trajektna Luka</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -199,11 +199,12 @@
     <string name="content_update_desc"><![CDATA[
     Hvala vam na dosad poslanim komentarima i prijavama pogreški! U ovoj verziji su:
     <br>
-    <br>* Popravljeni vozni redovi koji se nisu prikazivali, poput linija br. 5A, 10, a i par ostalih. Zbog većeg obujma promjena,
-    interna baza je znatnije izmjenjena što znači da će vam se favoriti poništiti. Isprike zbog navedenog!
-    <br>* Dodane linija br. 15 na interaktivnoj karti. Dodaju se i ostale, ali vas molim za malo strpljenja
+    <br>* Popravljeni vozni redovi koji se nisu prikazivali, poput linija br. 5A, 10, a i par ostalih
+    <br>* Dodane linija br. 15 na interaktivnoj karti
     <br>* Ispravljene pokoje greškice i nadograđeni interni alati
     <br>
+    <br>
+    <b>NAPOMENA:</b> Favoriti će se Vam se poništiti jer je interna baza nadograđena, ispričavam se zbog toga toga!
     ]]>
     </string>
 
@@ -369,6 +370,5 @@
     <string name="buss2">Rogač - Grohote - Srednje Selo - Donje Selo - Maslinica</string>
     <string name="buss3">Stomorska - Gornje Selo - Nečujam - Grohote - Rogač</string>
     <string name="buss4">Rogač - Grohote - Nečujam - Gornje Selo - Stomorska</string>
-    <string name="buss5">Trogir - Plano - Maljkovići</string>
 
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -199,8 +199,9 @@
     <string name="content_update_desc"><![CDATA[
     Hvala vam na dosad poslanim komentarima i prijavama pogreški! U ovoj verziji su:
     <br>
-    <br>* Dodane linije br. 9 i 11 na interaktivnoj karti. Dodaju se i ostale, ali vas molim za malo strpljenja
-    <br>* Ispravke na rutama 7 i 8
+    <br>* Popravljeni vozni redovi koji se nisu prikazivali, poput linija br. 5A, 10, a i par ostalih. Zbog većeg obujma promjena,
+    interna baza je znatnije izmjenjena što znači da će vam se favoriti poništiti. Isprike zbog navedenog!
+    <br>* Dodane linija br. 15 na interaktivnoj karti. Dodaju se i ostale, ali vas molim za malo strpljenja
     <br>* Ispravljene pokoje greškice i nadograđeni interni alati
     <br>
     ]]>
@@ -246,7 +247,7 @@
     <string name="bus81">Žnjan - Zvončac</string>
     <string name="bus82">Zvončac - Žnjan</string>
     <string name="bus9">Ravne Njive - Trajektna Luka - Ravne Njive</string>
-    <string name="bus10">Japirko - HNK - Japirko</string>
+    <string name="bus10">Japirko - Trajektna Luka - Japirko</string>
     <string name="bus11">Ravne Njive - Pujanke - HNK - Ravne Njive</string>
     <string name="bus121">Sv.Frane - Bene</string>
     <string name="bus122">Bene - Meje - Sv.Frane</string>
@@ -335,24 +336,32 @@
 
 
     <!-- Trogir -->
-    <string name="bus411">Trogir - Plano - Maljkovići</string>
-    <string name="bus412">Maljkovići - Plano - Trogir</string>
+    <string name="bus411">Trogir - Plano</string>
+    <string name="bus412">Plano - Trogir</string>
     <string name="bus421">Trogir - Slatine</string>
     <string name="bus422">Slatine - Trogir</string>
     <string name="bus441">Trogir - Okrug Donji</string>
     <string name="bus442">Okrug Donji - Trogir</string>
-    <string name="bus451">Trogir - Hotel Medena - Vranjica</string>
-    <string name="bus452">Vranjica - Hotel Medena - Trogir</string>
-    <string name="bus47">Trogir - Hotel Medena - Vrsine - Marina - Trogir</string>
-    <string name="bus48">Trogir - Hotel Medena - Marina - Dograde - Vrsine - Trogir</string>
-    <string name="bus491">Trogir - Hotel Medena - Vinišće</string>
-    <string name="bus492">Vinišće - Hotel Medena - Trogir</string>
-    <string name="bus501">Trogir - Hotel Medena - Sevid</string>
-    <string name="bus502">Sevid - Hotel Medena - Trogir</string>
-    <string name="bus511">Trogir - Ljubitovica</string>
+    <string name="bus451">Trogir - Seget Vranjica</string>
+    <string name="bus452">Seget Vranjica - Trogir</string>
+    <string name="bus471">Trogir - Marina</string>
+    <string name="bus472">Marina - Trogir</string>
+    <string name="bus4911">Trogir - Marina - Vinišće</string>
+    <string name="bus4912">Trogir - Vrsine - Marina - Vinišće</string>
+    <string name="bus4921">Vinišće - Marina</string>
+    <string name="bus4922">Vinišće - Marina - Trogir</string>
+    <string name="bus5011">Trogir - Vrsine - Marina - Sevid</string>
+    <string name="bus5012">Trogir - Marina - Vinišće - Sevid</string>
+    <string name="bus5021">Sevid - Vinišće - Trogir</string>
+    <string name="bus5022">Sevid - Trogir</string>
+    <string name="bus5023">Sevid - Marina</string>
+    <string name="bus511">Trogir - Bristivica - Ljubitovica</string>
     <string name="bus512">Ljubitovica - Trogir</string>
-    <string name="bus521">Trogir - Vinovac</string>
-    <string name="bus522">Vinovac - Trogir</string>
+    <string name="bus5211">Trogir - Vrsine - Marina - Vinovac</string>
+    <string name="bus5212">Vinovac - Blizna - Dograde - Marina - Trogir</string>
+    <string name="bus5213">Marina (okretište) - Vinovac</string>
+    <string name="bus5214">Vinovac - Blizna - Marina - Dograde - Vrsine - Trogir</string>
+    <string name="bus5215">Vinovac - Blizna - Marina - Trogir</string>
 
 
     <!-- Trogir -->

--- a/app/src/main/res/values-night/bool.xml
+++ b/app/src/main/res/values-night/bool.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values/bool.xml
+++ b/app/src/main/res/values/bool.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values/drawables.xml
+++ b/app/src/main/res/values/drawables.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,11 +195,12 @@
     <string name="content_update_desc"><![CDATA[
     Thank you all for your feedback and bug reports! This release contains following:
     <br>
-    <br>* Timetable updates, fixes for various timetables not loading including 5A, 10 and others. Unfortunately
-    favourites had to be reset!
+    <br>* Timetable updates, fixes for various timetables not loading including 5A, 10 and others
     <br>* Added line 15 on the interactive map, please check routes and report any issues!
     <br>* More internal bug fixes and updates
     <br>
+    <br>
+    <b>NOTE:</b> Your favourites will reset as internal database has been upgraded! Apologies for this!
     ]]>
     </string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,8 +195,9 @@
     <string name="content_update_desc"><![CDATA[
     Thank you all for your feedback and bug reports! This release contains following:
     <br>
-    <br>* Added lines 9 and 11 on the interactive map, please check routes and report any issues!
-    <br>* Changes on routes 7 and 8
+    <br>* Timetable updates, fixes for various timetables not loading including 5A, 10 and others. Unfortunately
+    favourites had to be reset!
+    <br>* Added line 15 on the interactive map, please check routes and report any issues!
     <br>* More internal bug fixes and updates
     <br>
     ]]>
@@ -241,7 +242,7 @@
     <string name="bus81">Žnjan - Zvončac</string>
     <string name="bus82">Zvončac - Žnjan</string>
     <string name="bus9">Ravne Njive - Ferry Port - Ravne Njive</string>
-    <string name="bus10">Japirko - HNK - Japirko</string>
+    <string name="bus10">Japirko - Ferry Port - Japirko</string>
     <string name="bus11">Ravne Njive - Pujanke - HNK - Ravne Njive</string>
     <string name="bus121">Sv.Frane - Bene</string>
     <string name="bus122">Bene - Meje - Sv.Frane</string>
@@ -255,8 +256,8 @@
     <string name="bus21">Sv.Frane - Meje - Sv.Frane</string>
     <string name="bus22">Klis Megdan - Gornja Rupotina - HNK - Klis Megdan</string>
     <string name="bus23">(N) HNK - Solin - HNK</string>
-    <string name="bus241">Split - Kopilica - Dom. Rata - Stobreč - TTTS</string>
-    <string name="bus242">TTTS - Stobreč - Dom. Rata - Kopilica - Split</string>
+    <string name="bus241">Split - Poljička - TTTS</string>
+    <string name="bus242">TTTS - Poljička - Split</string>
     <string name="bus251">Split - Stobreč</string>
     <string name="bus252">Stobreč - Split</string>
     <string name="bus261">Split - Kamen</string>
@@ -330,32 +331,39 @@
 
 
     <!-- Trogir -->
-    <string name="bus411">Trogir - Plano - Maljkovići</string>
-    <string name="bus412">Maljkovići - Plano - Trogir</string>
+    <string name="bus411">Trogir - Plano</string>
+    <string name="bus412">Plano - Trogir</string>
     <string name="bus421">Trogir - Slatine</string>
     <string name="bus422">Slatine - Trogir</string>
     <string name="bus441">Trogir - Okrug Donji</string>
     <string name="bus442">Okrug Donji - Trogir</string>
-    <string name="bus451">Trogir - Hotel Medena - Vranjica</string>
-    <string name="bus452">Vranjica - Hotel Medena - Trogir</string>
-    <string name="bus47">Trogir - Hotel Medena - Vrsine - Marina - Trogir</string>
-    <string name="bus48">Trogir - Hotel Medena - Marina - Dograde - Vrsine - Trogir</string>
-    <string name="bus491">Trogir - Hotel Medena - Vinišće</string>
-    <string name="bus492">Vinišće - Hotel Medena - Trogir</string>
-    <string name="bus501">Trogir - Hotel Medena - Sevid</string>
-    <string name="bus502">Sevid - Hotel Medena - Trogir</string>
-    <string name="bus511">Trogir - Ljubitovica</string>
+    <string name="bus451">Trogir - Seget Vranjica</string>
+    <string name="bus452">Seget Vranjica - Trogir</string>
+    <string name="bus471">Trogir - Marina</string>
+    <string name="bus472">Marina - Trogir</string>
+    <string name="bus4911">Trogir - Marina - Vinišće</string>
+    <string name="bus4912">Trogir - Vrsine - Marina - Vinišće</string>
+    <string name="bus4921">Vinišće - Marina</string>
+    <string name="bus4922">Vinišće - Marina - Trogir</string>
+    <string name="bus5011">Trogir - Vrsine - Marina - Sevid</string>
+    <string name="bus5012">Trogir - Marina - Vinišće - Sevid</string>
+    <string name="bus5021">Sevid - Vinišće - Trogir</string>
+    <string name="bus5022">Sevid - Trogir</string>
+    <string name="bus5023">Sevid - Marina</string>
+    <string name="bus511">Trogir - Bristivica - Ljubitovica</string>
     <string name="bus512">Ljubitovica - Trogir</string>
-    <string name="bus521">Trogir - Vinovac</string>
-    <string name="bus522">Vinovac - Trogir</string>
+    <string name="bus5211">Trogir - Vrsine - Marina - Vinovac</string>
+    <string name="bus5212">Vinovac - Blizna - Dograde - Marina - Trogir</string>
+    <string name="bus5213">Marina (okretište) - Vinovac</string>
+    <string name="bus5214">Vinovac - Blizna - Marina - Dograde - Vrsine - Trogir</string>
+    <string name="bus5215">Vinovac - Blizna - Marina - Trogir</string>
 
 
     <!-- Trogir -->
-    <string name="buss1">Maslinica - Donje Selo - Srednje Selo - Grohote - Rogač</string>
-    <string name="buss2">Rogač - Grohote - Srednje Selo - Donje Selo - Maslinica</string>
-    <string name="buss3">Stomorska - Gornje Selo - Nečujam - Grohote - Rogač</string>
-    <string name="buss4">Rogač - Grohote - Nečujam - Gornje Selo - Stomorska</string>
-    <string name="buss5">Trogir - Plano - Maljkovići</string>
+    <string name="buss1">Maslinica</string>
+    <string name="buss2">Rogač - Grohote - Srednje Selo</string>
+    <string name="buss3">Stomorska - Gornje Selo</string>
+    <string name="buss4">Rogač - Grohote - Nečujam</string>
 
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,8 @@
     <string name="gmaps_route_92">9 - Ferry Port &#8212;> Ravne Njive</string>
     <string name="gmaps_route_111">11 - Ravne Njive &#8212;> HNK</string>
     <string name="gmaps_route_112">11 - HNK &#8212;> Ravne Njive</string>
+    <string name="gmaps_route_151">15 - Duilovo &#8212;> Ferry Port</string>
+    <string name="gmaps_route_152">15 - Ferry Port &#8212;> Duilovo</string>
     <string name="gmaps_route_181">18 - Brnik &#8212;> HNK</string>
     <string name="gmaps_route_182">18 - HNK &#8212;> Brnik</string>
     <string name="gmaps_route_401">40 - Kila &#8212;> Ferry Port</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -2,7 +2,7 @@
 <!--
   ~ MIT License
   ~
-  ~ Copyright (c) 2013 - 2019 Antonio Marin
+  ~ Copyright (c) 2013 - 2021 Antonio Marin
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/app/src/test/java/com/am/stbus/ExampleUnitTest.kt
+++ b/app/src/test/java/com/am/stbus/ExampleUnitTest.kt
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2013 - 2019 Antonio Marin
+ * Copyright (c) 2013 - 2021 Antonio Marin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.gradle_version = '4.1.0'
-    ext.kotlin_version = '1.4.10'
+    ext.gradle_version = '4.1.2'
+    ext.kotlin_version = '1.4.21'
     ext.navigation_safe_args_version = '2.1.0-alpha05'
     ext.gms_services_version = '4.3.3'
     ext.licenses_version = '0.10.2'


### PR DESCRIPTION
# Split Bus v3.1.6 
* Popravljeni vozni redovi koji se nisu prikazivali, poput linija br. 5A, 10, a i par ostalih. Zbog većeg obujma promjena,
    interna baza je znatnije izmjenjena što znači da će vam se favoriti poništiti. Isprike zbog navedenog!
* Dodane linija br. 15 na interaktivnoj karti. Dodaju se i ostale, ali vas molim za malo strpljenja
* Ispravljene pokoje greškice i nadograđeni interni alati
